### PR TITLE
feat(strs): add Truncate function

### DIFF
--- a/strs/strs.go
+++ b/strs/strs.go
@@ -28,3 +28,39 @@ func Underscore(s string) string {
 
 	return builder.String()
 }
+
+// Truncate returns  truncated string of the specified length and
+// s consists entirely of valid UTF-8-encoded runes.
+func Truncate(s string, length int) string {
+	if length == 0 {
+		return ""
+	}
+
+	if length < 0 {
+		return s
+	}
+
+	size := len(s)
+	if size <= length {
+		return s
+	}
+
+	var (
+		n, i int
+		c    rune
+	)
+	for i, c = range s {
+		if n == length-1 {
+			break
+		}
+
+		n++
+	}
+
+	i += len(string(c))
+	if i > size {
+		i = size
+	}
+
+	return s[:i]
+}

--- a/strs/strs_test.go
+++ b/strs/strs_test.go
@@ -2,6 +2,7 @@ package strs
 
 import (
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -22,4 +23,105 @@ func TestUnderscore(t *testing.T) {
 	assert.Equal(t, "___foo1_bar1_bar2", Underscore("___Foo1Bar1Bar2"))
 	assert.Equal(t, "__1_foo1_bar1_bar2", Underscore("__1Foo1Bar1Bar2"))
 	assert.Equal(t, "__s1_foo1_bar1_bar2", Underscore("__s1Foo1Bar1Bar2"))
+}
+
+func TestTruncate(t *testing.T) {
+	s := "空山不见人，但闻人语响。返影入深林，复照青苔上。ABCabc,日a本b語ç日ð本Ê語þ日¥本¼語i日©☺☻☹"
+	for i := 0; i < 1000; i++ {
+		assert.Equal(t, pureTruncateWithTune(s, i), Truncate(s, i))
+	}
+
+}
+
+func FuzzTruncate(f *testing.F) {
+	f.Fuzz(func(t *testing.T, s string, i int) {
+		if utf8.ValidString(s) {
+			assert.Equal(t, pureTruncateWithTune(s, i), Truncate(s, i))
+		}
+	})
+}
+
+func truncateWithDecodeRuneInString(s string, length int) string {
+	if length == 0 {
+		return ""
+	}
+
+	if length < 0 {
+		return s
+	}
+
+	if len(s) <= length {
+		return s
+	}
+
+	var size, n int
+	for i := 0; i < length && n < len(s); i++ {
+		_, size = utf8.DecodeRuneInString(s[n:])
+		n += size
+	}
+
+	return s[:n]
+}
+
+func truncateWithTune(s string, length int) string {
+	if length == 0 {
+		return ""
+	}
+
+	if length < 0 {
+		return s
+	}
+
+	if len(s) <= length {
+		return s
+	}
+
+	if utf8.RuneCountInString(s) <= length {
+		return s
+	}
+
+	runes := []rune(s)
+	return string(runes[:length])
+}
+
+func pureTruncateWithTune(s string, length int) string {
+	if length < 0 {
+		return s
+	}
+
+	runes := []rune(s)
+	if length > len(runes) {
+		length = len(runes)
+	}
+	return string(runes[:length])
+}
+
+func Benchmark_truncateWithTune(b *testing.B) {
+	s := "空山不见人，但闻人语响。返影入深林，复照青苔上。"
+	size := utf8.RuneCountInString(s)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < size+1; j++ {
+			truncateWithTune(s, i)
+		}
+	}
+}
+
+func BenchmarkTruncate(b *testing.B) {
+	s := "空山不见人，但闻人语响。返影入深林，复照青苔上。"
+	size := utf8.RuneCountInString(s)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < size+1; j++ {
+			Truncate(s, i)
+		}
+	}
+}
+
+func Benchmark_truncateWithDecodeRuneInString(b *testing.B) {
+	s := "空山不见人，但闻人语响。返影入深林，复照青苔上。"
+	size := utf8.RuneCountInString(s)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < size+1; j++ {
+			truncateWithDecodeRuneInString(s, i)
+		}
+	}
 }

--- a/strs/strs_test.go
+++ b/strs/strs_test.go
@@ -30,7 +30,6 @@ func TestTruncate(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		assert.Equal(t, pureTruncateWithTune(s, i), Truncate(s, i))
 	}
-
 }
 
 func FuzzTruncate(f *testing.F) {


### PR DESCRIPTION
```
goos: windows
goarch: amd64
pkg: github.com/open-unbounded/go-pkg/strs
cpu: Intel(R) Core(TM) i5-8265UC CPU @ 1.60GHz
Benchmark_truncateWithTune
Benchmark_truncateWithTune-8                    15920355                74.31 ns/op
BenchmarkTruncate
BenchmarkTruncate-8                             54462522                23.74 ns/op
Benchmark_truncateWithDecodeRuneInString
Benchmark_truncateWithDecodeRuneInString-8      18179062                67.44 ns/op
PASS
```